### PR TITLE
Wallaby.js default behaviour change

### DIFF
--- a/test/testingSpec.coffee
+++ b/test/testingSpec.coffee
@@ -1,6 +1,6 @@
 assert = require 'assert'
 
-src = require '../src/testing.coffee'
+src = require '../src/testing'
 
 star = {Star:{}}
 func = (left, right) -> {Function:{left,right}}


### PR DESCRIPTION
Wallaby.js CoffeeScript compiler has changed the way it works by default so now it's possible to just require files without the `.coffee` extension.
if you'd still like to reference files with the `.coffee` extension, please have a look here how to configure wallaby.js to do it: https://github.com/wallabyjs/public#coffeescript-for-nodejs
